### PR TITLE
FIX: Swap Dependencies and Inspector ID

### DIFF
--- a/app/projects/templates/project_dashboard.html
+++ b/app/projects/templates/project_dashboard.html
@@ -159,12 +159,12 @@ that could compromise the confidentiality, integrity, or availability of the sys
                                                 Workbench
                                             </a>
                                             <a class="btn btn-default"
-                                                href="/analysis/dependencies/{{ project.appinspector.id }}">
+                                                href="/analysis/dependencies/{{ project.analysis.id }}">
                                                 <span title="Dependencies" class="fas fa-sitemap"></span>
                                                 Dependencies
                                             </a>
                                             <a class="btn btn-default"
-                                                href="/analysis/inspector/{{ project.analysis.id }}">
+                                                href="/analysis/inspector/{{ project.appinspector.id }}">
                                                 <span title="Inspector" class="fas fa-list"></span>
                                                 Inspector
                                             </a>


### PR DESCRIPTION
Swapped the templated field to fill in on dependencies and inspector to fix a bug where the project dashboard links to view dependencies and visit the app inspector were broken.